### PR TITLE
Removed return type "Token" on "find" method 

### DIFF
--- a/src/CacheTokenRepository.php
+++ b/src/CacheTokenRepository.php
@@ -44,7 +44,7 @@ class CacheTokenRepository extends TokenRepository
      *
      * @return \Laravel\Passport\Token
      */
-    public function find($id): Token
+    public function find($id)
     {
         return Cache::remember($this->cacheKey . $id, \now()->addSeconds($this->expiresInSeconds), function () use ($id) {
             return Passport::token()->where('id', $id)->first();


### PR DESCRIPTION
I removed this because when the passed token does not exists the function returns Null and raise a TypeError exception.
With this Passport can use the "Null" token and raise a 403