### PR TITLE
Fix typerror bug

### DIFF
--- a/src/CacheTokenRepository.php
+++ b/src/CacheTokenRepository.php
@@ -53,7 +53,7 @@ class CacheTokenRepository extends TokenRepository
      *
      * @return \Laravel\Passport\Token
      */
-    public function find($id): Token
+    public function find($id): ?Token
     {
         return $this->cacheStore()->remember(
             $this->itemKey($id),


### PR DESCRIPTION
In the case when there is a null return from the ::find() the error message would be "
```
message": "Overtrue\\LaravelPassportCacheToken\\CacheTokenRepository::find(): Return value must be of type Laravel\\Passport\\Token, null returned",
"exception": "TypeError",
```
This pull requests addresses this typerror.